### PR TITLE
[parser] enable flags to be required or not

### DIFF
--- a/src/main/java/disparse/parser/Flag.java
+++ b/src/main/java/disparse/parser/Flag.java
@@ -5,12 +5,18 @@ import java.util.Objects;
 public class Flag {
     private final String longName;
     private final Character shortName;
+    private final boolean isRequired;
     private final Types type;
 
     public Flag(final String longName, final Character shortName, final Types type) {
+        this(longName, shortName, type, false);
+    }
+
+    public Flag(final String longName, final Character shortName, final Types type, final boolean isRequired) {
         this.longName = longName;
         this.shortName = shortName;
         this.type = type;
+        this.isRequired = isRequired;
     }
 
     public String getLongName() {
@@ -24,6 +30,8 @@ public class Flag {
     public Types getType() {
         return type;
     }
+
+    public boolean isRequired() { return isRequired; }
 
     @Override
     public String toString() {

--- a/src/main/java/disparse/parser/dispatch/CommandRegistrar.java
+++ b/src/main/java/disparse/parser/dispatch/CommandRegistrar.java
@@ -7,6 +7,8 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+
+import disparse.parser.exceptions.OptionRequired;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import disparse.parser.Flag;
@@ -74,6 +76,8 @@ public class CommandRegistrar {
                                 } else {
                                     field.set(newObject, val);
                                 }
+                            } else if (flag.isRequired()) {
+                                throw new OptionRequired(flag + " is required for command to be ran!");
                             }
                         }
                     }

--- a/src/main/java/disparse/parser/exceptions/OptionRequired.java
+++ b/src/main/java/disparse/parser/exceptions/OptionRequired.java
@@ -1,0 +1,5 @@
+package disparse.parser.exceptions;
+
+public class OptionRequired extends RuntimeException {
+    public OptionRequired(String message) { super(message); }
+}

--- a/src/main/java/disparse/parser/reflection/Flag.java
+++ b/src/main/java/disparse/parser/reflection/Flag.java
@@ -11,4 +11,6 @@ public @interface Flag {
     char shortName() default ' ';
 
     String longName() default "";
+
+    boolean required() default false;
 }

--- a/src/main/java/disparse/parser/reflection/Utils.java
+++ b/src/main/java/disparse/parser/reflection/Utils.java
@@ -9,6 +9,7 @@ public class Utils {
     public static disparse.parser.Flag createFlagFromAnnotation(Field field, Flag annotation) {
         String longName = annotation.longName();
         Character shortName = annotation.shortName();
+        boolean required = annotation.required();
         if (shortName == ' ') {
             shortName = null;
         }
@@ -23,6 +24,6 @@ public class Utils {
             type = Types.BOOL;
         }
 
-        return new disparse.parser.Flag(longName, shortName, type);
+        return new disparse.parser.Flag(longName, shortName, type, required);
     }
 }


### PR DESCRIPTION
Some commands may want to have a required flag, that means execution of the command cannot continue without this flag being present and provided by the user.  This could be achieved currently by using the wrapper class for primitives and checking for null in the command handler; then exiting out if a required flag is `null`.

This type of behavior seems fairly common; therefore, it should be added to the actual API of a Flag.  It is an optional field, defaulting to `required = False`.

Usage:

`@Flag(shortName = 'f', longName = "foo", required = True)`