### PR TITLE
[meta] add module-info for all modules

### DIFF
--- a/disparse-core/src/main/java/module-info.java
+++ b/disparse-core/src/main/java/module-info.java
@@ -1,0 +1,8 @@
+module disparse.core {
+  requires slf4j.api;
+  requires reflections;
+
+  exports disparse.discord;
+  exports disparse.parser;
+  exports disparse.utils.help;
+}

--- a/disparse-d4j/pom.xml
+++ b/disparse-d4j/pom.xml
@@ -24,6 +24,16 @@
             <artifactId>discord4j-core</artifactId>
             <version>3.1.0.RC2</version>
         </dependency>
+        <dependency>
+            <groupId>com.discord4j</groupId>
+            <artifactId>discord-json-api</artifactId>
+            <version>1.4.1</version>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+            <version>3.3.4.RELEASE</version>
+        </dependency>
     </dependencies>
 
 

--- a/disparse-d4j/src/main/java/module-info.java
+++ b/disparse-d4j/src/main/java/module-info.java
@@ -1,0 +1,10 @@
+module disparse.d4j {
+  requires discord4j.common;
+  requires discord4j.core;
+  requires discord4j.discordjson;
+  requires discord4j.discordjson.api;
+  requires discord4j.rest;
+  requires disparse.core;
+  requires reactor.core;
+  requires slf4j.api;
+}

--- a/disparse-jda/src/main/java/module-info.java
+++ b/disparse-jda/src/main/java/module-info.java
@@ -1,0 +1,6 @@
+module disparse.jda {
+  requires disparse.core;
+  requires jsr305;
+  requires net.dv8tion.jda;
+  requires slf4j.api;
+}

--- a/disparse-smalld/src/main/java/module-info.java
+++ b/disparse-smalld/src/main/java/module-info.java
@@ -1,0 +1,6 @@
+module disparse.smalld {
+  requires com.google.gson;
+  requires disparse.core;
+  requires slf4j.api;
+  requires smalld;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>3.8.1</version>
       </plugin>
       <plugin>
         <groupId>com.coveo</groupId>


### PR DESCRIPTION
add module-info for all modules
include dependencies so they are on the module path
update maven-compiler-plugin to 3.8.1