### PR TITLE
[core] Allow flags to specify only a shortFlag

### DIFF
--- a/disparse-core/src/main/java/disparse/discord/AbstractDispatcher.java
+++ b/disparse-core/src/main/java/disparse/discord/AbstractDispatcher.java
@@ -92,6 +92,8 @@ public abstract class AbstractDispatcher<E, T> {
     if (!this.disabledCommandManager.commandAllowedInGuild(this.guildFromEvent(event), command))
       return;
 
+    if (!this.runMiddleware(event, command.getCommandName())) return;
+
     T builder = this.baseEmbedManager.baseHelpEmbedForGuild(event, this);
     setBuilderTitle(builder, Help.getTitle(command));
     setBuilderDescription(builder, Help.getDescriptionUsage(command));
@@ -181,6 +183,7 @@ public abstract class AbstractDispatcher<E, T> {
         commands.stream()
             .filter(c -> this.disabledCommandManager.commandAllowedInGuild(guildId, c))
             .filter(c -> !this.commandRolesNotMet(event, c) && !this.commandIntentsNotMet(event, c))
+            .filter(c -> this.runMiddleware(event, c.getCommandName()))
             .collect(Collectors.toList());
 
     T builder = this.baseEmbedManager.baseHelpEmbedForGuild(event, this);

--- a/disparse-core/src/main/java/disparse/parser/CommandFlag.java
+++ b/disparse-core/src/main/java/disparse/parser/CommandFlag.java
@@ -5,8 +5,8 @@ import java.util.Objects;
 
 public class CommandFlag {
 
-  private final String longName;
-  private final Character shortName;
+  private final String longName; // This should be Optional
+  private final Character shortName; // This should be Optional
   private final boolean isRequired;
   private final Types type;
   private final String description;
@@ -66,7 +66,7 @@ public class CommandFlag {
       return false;
     }
     CommandFlag flag = (CommandFlag) o;
-    return longName.equals(flag.longName) && Objects.equals(shortName, flag.shortName);
+    return Objects.equals(longName, flag.longName) && Objects.equals(shortName, flag.shortName);
   }
 
   @Override

--- a/disparse-core/src/main/java/disparse/utils/help/Help.java
+++ b/disparse-core/src/main/java/disparse/utils/help/Help.java
@@ -3,10 +3,7 @@ package disparse.utils.help;
 import disparse.parser.Command;
 import disparse.parser.CommandFlag;
 import disparse.parser.Types;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -78,9 +75,22 @@ public class Help {
   }
 
   public static String optionRequired(Command command, CommandFlag flag) {
-    return "The flag `--"
-        + flag
-        + "` is required for `"
+
+    Optional<String> longDisplay =
+        Optional.ofNullable(flag.getLongName()).map(s -> "`--" + s + "`");
+
+    Optional<String> shortDisplay =
+        Optional.ofNullable(flag.getShortName()).map(s -> "`-" + s + "`");
+
+    String flagDisplay =
+        longDisplay
+            .or(() -> shortDisplay)
+            .orElseThrow(
+                () -> new RuntimeException("Flag had neither short nor long flag registered!"));
+
+    return "The flag "
+        + flagDisplay
+        + " is required for `"
         + command.getCommandName()
         + "` to be ran!";
   }


### PR DESCRIPTION
Before there were limitations and a flag could only specify either:

  1. A longFlag
  2. A longFlag and a shortFlag
  
Update the limitation so that now you can specify either one in isolation as well as specifying them both together.  It should fail when there is neither a longFlag and shortFlag but the error message at the moment is probably poor so that would be future work on the parser side.